### PR TITLE
Change apt-get to apt, as apt-get is semi-deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ brew install dialog
 ### Linux (Debian/Ubuntu)
 
 ```bash
-sudo apt-get install dialog
+sudo apt install dialog
 ```
 
 ### Windows


### PR DESCRIPTION
Hey, I just changed the README so it tells you to use apt instead, as apt-get is kind of no longer recommended to use:)